### PR TITLE
Use java 8 as java home for toolchain in indy-build

### DIFF
--- a/indy-build.Jenkinsfile
+++ b/indy-build.Jenkinsfile
@@ -119,7 +119,7 @@ pipeline {
     }
     stage('Build'){
       steps{
-        withEnv(['JAVA_HOME=/usr/lib/jvm/java-11-openjdk']){
+        withEnv(['JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk']){
           dir("indy"){
             echo "Executing build for : ${params.INDY_GIT_REPO} ${params.INDY_MAJOR_VERSION}"
             sh "mvn -B -V clean verify -DskipNpmConfig=false --global-toolchains toolchains.xml"
@@ -141,7 +141,7 @@ pipeline {
         }
       }
       steps {
-        withEnv(['JAVA_HOME=/usr/lib/jvm/java-11-openjdk']){
+        withEnv(['JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk']){
           dir("indy"){
             sh 'mvn -B -V verify -Prun-its -Pci -DskipNpmConfig=false --global-toolchains toolchains.xml'
           }
@@ -282,7 +282,7 @@ pipeline {
         }
       }
       steps {
-        withEnv(['JAVA_HOME=/usr/lib/jvm/java-11-openjdk']){
+        withEnv(['JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk']){
           dir("indy"){
             script{
               sh """


### PR DESCRIPTION
Seems java-11-openjdk does not have jre in it, which cause maven compains.